### PR TITLE
Added quiet mode to optionally suppress log messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,8 @@ export default function(settings?: ProblemMwSettings): Middleware {
         ctx.response.body.detail = detail;
       }
 
-      if (settings && !settings.quiet) {
-        if (clientError) {
+      if (settings) {
+        if (clientError && settings.quiet === false) {
           // tslint:disable-next-line no-console
           console.warn(e);
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import { Middleware } from '@curveball/core';
 import { HttpProblem, isClientError, isHttpError } from '@curveball/http-errors';
 
 type ProblemMwSettings = {
-  debug: boolean,
+  debug: boolean | undefined,
+  quiet: boolean | undefined,
 };
 
 export default function(settings?: ProblemMwSettings): Middleware {
@@ -69,14 +70,15 @@ export default function(settings?: ProblemMwSettings): Middleware {
         ctx.response.body.detail = detail;
       }
 
-      if (clientError) {
-        // tslint:disable-next-line no-console
-        console.warn(e);
-      } else {
-        // tslint:disable-next-line no-console
-        console.error(e);
+      if (settings && !settings.quiet) {
+        if (clientError) {
+          // tslint:disable-next-line no-console
+          console.warn(e);
+        } else {
+          // tslint:disable-next-line no-console
+          console.error(e);
+        }
       }
-
     }
 
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,11 @@ export default function(settings?: ProblemMwSettings): Middleware {
     debugMode = true;
   }
 
+  let quiet = false;
+  if (settings && settings.quiet !== undefined) {
+    quiet = settings.quiet
+  }
+
   return async (ctx, next) => {
 
     try {
@@ -70,14 +75,14 @@ export default function(settings?: ProblemMwSettings): Middleware {
         ctx.response.body.detail = detail;
       }
 
-      if (settings) {
-        if (clientError && settings.quiet === false) {
+      if (clientError) {
+        if (!quiet) {
           // tslint:disable-next-line no-console
           console.warn(e);
-        } else {
-          // tslint:disable-next-line no-console
-          console.error(e);
         }
+      } else {
+        // tslint:disable-next-line no-console
+        console.error(e);
       }
     }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -134,20 +134,30 @@ describe('Problem middleware', () => {
 
   });
 
-  it('should not log to the console if quiet mode is set', async() => {
+  it('should not log client warnings to the console if quiet mode is set', async() => {
+    const consoleStub = stub(console, 'warn');
+
+    await tester( () => {
+      throw new Unauthorized('Zzz', ['Bearer', 'Digest']);
+    }, false, true);
+
+    expect(consoleStub.notCalled).to.be.true;
+
+    await tester( () => {
+      throw new Unauthorized('Zzz', ['Bearer', 'Digest']);
+    }, false, false);
+
+    expect(consoleStub.calledOnce).to.be.true;
+  })
+
+  it ('should log internal errors to the console if quiet mode is set', async() => {
     const consoleStub = stub(console, 'error');
 
     await tester( () => {
-      throw new Error('Hello');
+      throw new Error();
     }, false, true);
 
-    expect(consoleStub.notCalled).to.be.true
-
-    await tester( () => {
-      throw new Error('Hello');
-    }, false, false);
-
-    expect(consoleStub.calledOnce).to.be.true
+    expect(consoleStub.calledOnce).to.be.true;
   })
 
   it('should also correctly pick up "httpError" properties', async () => {


### PR DESCRIPTION
Hi, I was testing some expected failure responses from a Curveball app and became mildly irritated by the exception stack traces showing up in my test outputs for passing tests. So I thought it would be nice if there was a "quiet" option to allow me to disable logging depending on the environment variable. What do you think?