### PR TITLE
fix: Make options explicitly optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import { Middleware } from '@curveball/core';
 import { isClientError, isHttpError, isHttpProblem } from '@curveball/http-errors';
 
 type ProblemMwSettings = {
-  debug?: boolean,
-  quiet?: boolean,
+  debug?: boolean;
+  quiet?: boolean;
 };
 
 export default function(settings?: ProblemMwSettings): Middleware {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import { Middleware } from '@curveball/core';
 import { HttpProblem, isClientError, isHttpError } from '@curveball/http-errors';
 
 type ProblemMwSettings = {
-  debug: boolean | undefined,
-  quiet: boolean | undefined,
+  debug?: boolean,
+  quiet?: boolean,
 };
 
 export default function(settings?: ProblemMwSettings): Middleware {


### PR DESCRIPTION
This PR makes options explicitly optional, instead of requiring you to explicitly set all unused options to `undefined.` 